### PR TITLE
Fix deprecated ember-addon definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "ember-cli-super-number",
   "version": "0.1.0",
-  "ember-addon-main": "lib/ember-cli-super-number.js",
+  "ember-addon": {
+    "main": "lib/ember-cli-super-number.js"
+  },
   "directories": {
     "doc": "doc",
     "test": "test"


### PR DESCRIPTION
I was getting this deprecation error:

``` shell
→ ember server
version: 0.1.7
DEPRECATION: ember-cli-super-number is using the deprecated ember-addon-main definition. It should be updated to {'ember-addon': {'main': 'lib/ember-cli-super-number.js'}}
DEPRECATION: ember-cli-super-number is using the deprecated ember-addon-main definition. It should be updated to {'ember-addon': {'main': 'lib/ember-cli-super-number.js'}}
...
```

This change updates the addon definition with newest syntax. 
